### PR TITLE
fix bug

### DIFF
--- a/cocoNLP/config/basic/time_nlp/TimeNormalizer.py
+++ b/cocoNLP/config/basic/time_nlp/TimeNormalizer.py
@@ -79,13 +79,15 @@ class TimeNormalizer:
             holi_lunar = json.load(f)
         return pattern, holi_solar, holi_lunar
 
-    def parse(self, target, timeBase=arrow.now()):
+    def parse(self, target, timeBase=None):
         """
         TimeNormalizer的构造方法，timeBase取默认的系统当前时间
         :param timeBase: 基准时间点
         :param target: 待分析字符串
         :return: 时间单元数组
         """
+        if timeBase is None:
+            timeBase = arrow.now()
         self.isTimeSpan = False
         self.invalidSpan = False
         self.timeSpan = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pyhanlp
 phone
 phonenumbers
 regex
-arrow
+arrow==0.14.3


### PR DESCRIPTION
arrow 最新版本已经废弃了一些方法 
TimeNormalizer.parse(self, target, timeBase=arrow.now())这样定义，在extractor.extrac_time()方法中会导致timeBase的值一只不会被改变。